### PR TITLE
Bug Fix: Deployments with Deleted Tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@im-open/im-github-deployments",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@im-open/im-github-deployments",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -156,7 +156,7 @@ export class GithubDeploymentsApiClient implements GithubDeploymentsApi {
           deployment_node_id: deployment.id,
           state: status.state,
           environment: deployment.environment,
-          ref: deployment.ref.name,
+          ref: deployment.ref?.name,
           created_at: DateTime.fromISO(status.createdAt),
           createdHuman: DateTime.fromISO(status.createdAt).toRelative({
             locale: 'en',

--- a/src/components/Deployments/columns.tsx
+++ b/src/components/Deployments/columns.tsx
@@ -140,6 +140,7 @@ class columnFactory {
         return diffValue;
       },
       render: (row: EnvDeployment) => {
+        const isBlank = !row.ref || row.ref == null || row.ref.trim() == '';
         const context = this.getContext(row.payload.workflow_run_url as string);
         const tagTest = semver.parse(row.ref);
         const shaTest = this.shaRegExp.exec(row.ref);
@@ -152,7 +153,7 @@ class columnFactory {
           url = `https://${context.server}/${context.owner}/${context.repo}/commit/${row.ref}`;
         }
 
-        return this.buildLink(url, row.ref);
+        return isBlank ? 'UNSPECIFIED' : this.buildLink(url, row.ref);
       },
     };
   }


### PR DESCRIPTION
# Summary of PR changes
This fixes a bug when a GitHub tag gets deleted after a deployment has been created.

Fixes this error:
<img width="764" alt="image" src="https://github.com/im-open/im-github-deployments/assets/13870231/11f54acb-e050-41d0-bccb-fb0d31eb61a5">

To this:
<img width="1100" alt="image" src="https://github.com/im-open/im-github-deployments/assets/13870231/89810f6f-23b2-402f-ab64-4e69f420cf92">


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
