### PR TITLE
Added default sorting environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ metadata:
 
 #### 2. `deployment-environments` - OPTIONAL, but recommended
 
-Adding the `metadata.deployment-environments` list allows the dashboard to be pre-populated with the expected deployment environments, and order their appearance in the dashboard.  Otherwise, the deployment environments will be ordered by how they were deployed and may not fully reflect the project deployment lifecycle.
+Adding the `metadata.deployment-environments` list allows the dashboard to be pre-populated with the expected deployment environments, and order their appearance in the dashboard.  Otherwise, the deployment environments will be assumed to be:
+
+- Dev
+- QA
+- Stage
+- UAT
+- Prod
+- Demo
+- Any other environments after this are ordered alphabetically
 
 ```yaml
 apiVersion: backstage.io/v1alpha1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@im-open/im-github-deployments",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Summary of PR changes

This PR adds a default list of environments for sorting when `catalog-info.yml` files don't specify the `deployment-environments` tag. 

Environments not on the known environments list will be sorted alphabetically.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
