### PR TITLE
Only push in deployments with statuses returned.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@im-open/im-github-deployments",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -136,25 +136,27 @@ export class GithubDeploymentsApiClient implements GithubDeploymentsApi {
       for (let i = 0; i < d.deployments.length; i++) {
         let deployment = d.deployments[i];
 
-        let noInactiveStatuses = deployment.statuses.nodes.filter(
-          s => s.state.toUpperCase() != 'INACTIVE',
-        );
-        let status =
-          noInactiveStatuses.length > 0
-            ? noInactiveStatuses[0]
-            : deployment.statuses.nodes[0];
+        if (deployment.statuses.nodes.length > 0) {
+          let noInactiveStatuses = deployment.statuses.nodes.filter(
+            s => s.state.toUpperCase() != 'INACTIVE',
+          );
+          let status =
+            noInactiveStatuses.length > 0
+              ? noInactiveStatuses[0]
+              : deployment.statuses.nodes[0];
 
-        formatted.push({
-          deployment_id: deployment.databaseId,
-          deployment_node_id: deployment.id,
-          state: status.state,
-          environment: deployment.environment,
-          ref: deployment.ref?.name,
-          created_at: DateTime.fromISO(status.createdAt),
-          createdHuman: DateTime.fromISO(status.createdAt).toRelative({
-            locale: 'en',
-          }),
-        } as RestDeploymentStatus);
+          formatted.push({
+            deployment_id: deployment.databaseId,
+            deployment_node_id: deployment.id,
+            state: status.state,
+            environment: deployment.environment,
+            ref: deployment.ref?.name,
+            created_at: DateTime.fromISO(status.createdAt),
+            createdHuman: DateTime.fromISO(status.createdAt).toRelative({
+              locale: 'en',
+            }),
+          } as RestDeploymentStatus);
+        }
       }
 
       return formatted.sort((a, b) =>


### PR DESCRIPTION
# Summary of PR changes

Fixed a bug when deployments without statuses are returned.


## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
