### PR TITLE
Bug Fix: only show dashboard from repo for the specific entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@im-open/im-github-deployments",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -88,6 +88,7 @@ export class GithubDeploymentsApiClient implements GithubDeploymentsApi {
     )
       .filter(d => d.task === 'workflowdeploy')
       .map(d => formatDeployments(d))
+      .filter(d => d.payload.entity === params.entity)
       .sort((a, b) => (a.id > b.id ? 1 : -1));
 
     return restDeployments;


### PR DESCRIPTION
# Summary of PR changes

The dashboard was deployments at the repo level.  The fix will parse out only deployments with the specific backstage catalog entity id.

## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
